### PR TITLE
added more tags to flicker api to improve predicatbility when images …

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -20,6 +20,7 @@ function loadCityFromSearch(e) {
 	let city = "";
 	city = $("#searchId").val();
 	// call function to display all city data
+
 	loadCityData(city);
 }
 /**
@@ -168,8 +169,7 @@ function loadCityMap(city) {
 }
 // function loadCityPhotos(city) {
 function loadCityPhotos(city) {
-	var flickerURL = `https://www.flickr.com/services/rest/?method=flickr.photos.search&api_key=bfab214383112313808fbee8bd7fad3e&format=json&nojsoncallback=1&content_type=1&media=photos&tags=${city}`;
-	var imageURLs = [];
+	var flickerURL = `https://www.flickr.com/services/rest/?method=flickr.photos.search&api_key=bfab214383112313808fbee8bd7fad3e&tags=${city}+city%2C+${city}+monuments%2C+${city}+sunset%2C+${city}+beach%2C&safe_search=1&content_type=1&geo_context=2&format=json&nojsoncallback=1`;
 	// ajax here (getting the json object)
 	$.getJSON(flickerURL, function (json) {
 		for (var i = 0; i < 5; i++) {


### PR DESCRIPTION
…are shown

I believe I've added additional tags to the pictures to get a more predictable result. while it still will always be random. I learned a lot about the tagging system. flicker will grab a tag that's most relevant to the searched term example “Tahiti”. they aren’t exactly known for their buildings and monuments. so flicker will “pass up” tags that aren’t relevant and go to ones that are like “Tahiti beach”. I added a safe-search feature so nothing too crazy should show up. and added content type for outside
close #59 